### PR TITLE
SHIELD-15739: Replace CircleCI with a GitHub Action

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -778,7 +778,6 @@ workflows:
                 - master
 
   d2l:
-    when: false
     jobs:
 
       # Linux

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -778,6 +778,7 @@ workflows:
                 - master
 
   d2l:
+    when: false
     jobs:
 
       # Linux

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -44,7 +44,15 @@ jobs:
     # Mirrors the CircleCI test-go-windows gate
     - name: Run tests
       shell: bash
-      run: go test -short -race ./...
+      # Point TMP/TEMP at a path with no 8.3 short-name truncation. The default
+      # runner temp dir (C:\Users\RUNNER~1\...) makes the haproxy plugin tests
+      # compare a short-form socket path against a long-form glob result.
+      env:
+        TMP: C:\Temp
+        TEMP: C:\Temp
+      run: |
+        mkdir -p /c/Temp
+        go test -short -race ./...
 
   build:
     name: Build packages

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -1,0 +1,119 @@
+name: build-package
+on:
+  push:
+    tags:
+    # Tag format: d2l-<telegraf-version>-build<number> (e.g. d2l-1.23.1-build227)
+    - "d2l-*"
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test-linux:
+    name: Test (Linux)
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: Brightspace/third-party-actions@actions/checkout
+
+    - uses: Brightspace/third-party-actions@actions/setup-go
+      with:
+        go-version: "1.18"
+
+    # Mirrors the CircleCI test-go-linux gate
+    - name: Run tests
+      run: |
+        make deps
+        make tidy
+        make check
+        make check-deps
+        make test race_detector="-race"
+
+  test-windows:
+    name: Test (Windows)
+    runs-on: windows-latest
+
+    steps:
+    - uses: Brightspace/third-party-actions@actions/checkout
+
+    - uses: Brightspace/third-party-actions@actions/setup-go
+      with:
+        go-version: "1.18"
+
+    # Mirrors the CircleCI test-go-windows gate
+    - name: Run tests
+      shell: bash
+      run: go test -short -race ./...
+
+  build:
+    name: Build packages
+    needs: [test-linux, test-windows]
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: Brightspace/third-party-actions@actions/checkout
+
+    - uses: Brightspace/third-party-actions@actions/setup-go
+      with:
+        go-version: "1.18"
+
+    - name: Compute version
+      id: version
+      run: |
+        # On pull requests there is no release tag; use a placeholder version so
+        # the build/packaging can be exercised without tag validation.
+        if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+          version="$(cat build_version.txt)-pr${{ github.event.pull_request.number }}"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "gitsha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        if [[ ! "${GITHUB_REF_NAME}" =~ ^d2l-[0-9]+\.[0-9]+\.[0-9]+-build[0-9]+$ ]]; then
+          echo "::error::Tag '${GITHUB_REF_NAME}' must match d2l-<telegraf-version>-build<number> (e.g. d2l-1.23.1-build227)"
+          exit 1
+        fi
+
+        version="${GITHUB_REF_NAME#d2l-}"
+
+        expected="$(cat build_version.txt)"
+        if [[ "${version}" != "${expected}-build"* ]]; then
+          echo "::error::Tag telegraf-version '${version%-build*}' does not match build_version.txt (${expected})"
+          exit 1
+        fi
+
+        echo "version=${version}" >> "$GITHUB_OUTPUT"
+        echo "gitsha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+    - name: Build packages
+      env:
+        VERSION: ${{ steps.version.outputs.version }}
+      run: |
+        export PATH="$PATH:$(go env GOPATH)/bin"
+        command -v fpm >/dev/null || sudo gem install --no-document fpm
+        make versioninfo version="$VERSION"
+        make package \
+          version="$VERSION" \
+          tar_version="$VERSION" \
+          deb_version="$VERSION-1" \
+          deb_iteration=1 \
+          include_packages="windows_amd64.zip static_linux_amd64.tar.gz amd64.deb"
+        test -f build/windows-amd64/telegraf.exe
+
+    - name: Stage package input
+      run: |
+        mkdir -p package-input/dist
+        cp build/windows-amd64/telegraf.exe package-input/
+        cp d2l.telegraf.nuspec package-input/
+        cp build/dist/*_static_linux_amd64.tar.gz package-input/dist/
+        cp build/dist/*_amd64.deb package-input/dist/
+        echo "${{ steps.version.outputs.version }}" > package-input/version.txt
+        echo "${{ steps.version.outputs.gitsha }}" > package-input/gitsha.txt
+
+    - uses: Brightspace/third-party-actions@actions/upload-artifact
+      if: github.event_name == 'push'
+      with:
+        name: telegraf-package-input
+        path: package-input/
+        if-no-files-found: error

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,14 +1,7 @@
 name: golangci-lint
+# Disabled in the D2L fork (third party actions cannot be run in this repo)
 on:
-  push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - master
-  schedule:
-    # Trigger every day at 16:00 UTC
-    - cron:  '0 16 * * *'
+  workflow_dispatch:
 jobs:
   golangci-pr:
     if: github.ref != 'refs/heads/master'

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -14,12 +14,10 @@ name: Lint Code Base
 #############################
 # Start the job on all push #
 #############################
+
+# Disabled in the D2L fork (third party actions cannot be run in this repo)
 on:
-  push:
-    branches-ignore: [master, main]
-    # Remove the line above to run when pushing to master
-  pull_request:
-    branches: [master, main]
+  workflow_dispatch:
 
 ###############
 # Set the Job #

--- a/.github/workflows/semantic.yml
+++ b/.github/workflows/semantic.yml
@@ -1,11 +1,9 @@
 ---
 name: "Semantic PR and Commit Messages"
 
+# Disabled in the D2L fork (third party actions cannot be run in this repo)
 on:
-  pull_request:
-    types: [opened, reopened, synchronize, edited]
-    branches:
-      - master
+  workflow_dispatch:
 
 jobs:
   semantic:

--- a/plugins/inputs/cloud_pubsub_push/cloud_pubsub_push_test.go
+++ b/plugins/inputs/cloud_pubsub_push/cloud_pubsub_push_test.go
@@ -125,7 +125,7 @@ func TestServeHTTP(t *testing.T) {
 			sem:          make(chan struct{}, 1),
 			undelivered:  make(map[telegraf.TrackingID]chan bool),
 			mu:           &sync.Mutex{},
-			WriteTimeout: config.Duration(time.Millisecond * 10),
+			WriteTimeout: config.Duration(time.Millisecond * 250),
 		}
 
 		pubPush.ctx, pubPush.cancel = context.WithCancel(context.Background())

--- a/plugins/inputs/x509_cert/x509_cert.go
+++ b/plugins/inputs/x509_cert/x509_cert.go
@@ -153,7 +153,14 @@ func (c *X509Cert) getCert(u *url.URL, timeout time.Duration) ([]*x509.Certifica
 
 		return certs, nil
 	case "file":
-		content, err := os.ReadFile(u.Path)
+		filename := u.Path
+		if u.Host != "" {
+			// On Windows an absolute path such as C:\foo is rewritten to
+			// file://C:/foo, so url.Parse treats the drive (C:) as the host.
+			// Rejoin it with the path to recover the full filename.
+			filename = u.Host + u.Path
+		}
+		content, err := os.ReadFile(filename)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
We no longer use CircleCI, so building a GH Action to build artifacts to be published by telegraf-publisher